### PR TITLE
Webサーバにアタッチするデバイスの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 ## 各章単位での作業実施 Pull-Request 一覧
 ### Chapter.2 ネットワークを構築する
 
-[Chapter 2 : ネットワークを構築する (#1)](https://github.com/a-know/aws-network-basic/pull/1)
+- [Chapter 2 : ネットワークを構築する (#1)](https://github.com/a-know/aws-network-basic/pull/1)
 
 
 ### Chapter.3 サーバーを構築する
 
-[Chapter 3 : サーバーを構築する (#2)](https://github.com/a-know/aws-network-basic/pull/2)
-[Webサーバにアタッチするデバイスの修正 (#3)](https://github.com/a-know/aws-network-basic/pull/3)
+- [Chapter 3 : サーバーを構築する (#2)](https://github.com/a-know/aws-network-basic/pull/2)
+- [Webサーバにアタッチするデバイスの修正 (#3)](https://github.com/a-know/aws-network-basic/pull/3)

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@
 ### Chapter.3 サーバーを構築する
 
 [Chapter 3 : サーバーを構築する (#2)](https://github.com/a-know/aws-network-basic/pull/2)
+[Webサーバにアタッチするデバイスの修正 (#3)](https://github.com/a-know/aws-network-basic/pull/3)

--- a/template.json
+++ b/template.json
@@ -91,16 +91,12 @@
         ],
         "BlockDeviceMappings" : [
           {
-            "DeviceName" : "/dev/sda1",
+            "DeviceName" : "/dev/xvda",
             "Ebs" : {
                "VolumeType" : "standard",
                "DeleteOnTermination" : "true",
                "VolumeSize" : "8"
             }
-          },
-          {
-            "DeviceName" : "/dev/sdk",
-            "NoDevice" : {}
           }
         ]
       }


### PR DESCRIPTION
#2 の状態で EC2 インスタンスが起動しなかった（ `stopping` のままだった）のは、Webサーバにアタッチするデバイスの指定に誤りがあったことによるもよう。
（「状態遷移の理由」が `Client.InstanceInitiatedShutdown: Instance initiated shutdown` で、すぐに停止する）

この p-r の修正を加えることで正常に起動できるようになった。